### PR TITLE
Fix issue return end of non-void function

### DIFF
--- a/src/SharpIR.cpp
+++ b/src/SharpIR.cpp
@@ -38,7 +38,7 @@ uint8_t SharpIR::getDistance( bool avoidBurstRead )
 				else if(distance < 20) return 19;
 				else return distance;
 
-			break:
+			default:
 				return 0;
 		}
 	}

--- a/src/SharpIR.cpp
+++ b/src/SharpIR.cpp
@@ -37,5 +37,8 @@ uint8_t SharpIR::getDistance( bool avoidBurstRead )
 				if(distance > 150) return 151;
 				else if(distance < 20) return 19;
 				else return distance;
+
+			break:
+				return 0;
 		}
 	}


### PR DESCRIPTION
In the current code with the switch function, a default is missing, which causes the following issue

```c++
..Arduino\libraries\SharpIR\src\SharpIR.cpp: In member function 'uint8_t SharpIR::getDistance(bool)':
..Arduino\libraries\SharpIR\src\SharpIR.cpp:41:2: error: control reaches end of non-void function [-Werror=return-type]
   41 |  }
      |  ^
cc1plus.exe: some warnings being treated as errors
```